### PR TITLE
공연 시설 상세 조회 API 추가

### DIFF
--- a/__tests__/kopis.test.ts
+++ b/__tests__/kopis.test.ts
@@ -1,6 +1,7 @@
 import {
   getPerformanceBoxOffice,
   getPerformanceDetail,
+  getPerformanceFacilityDetail,
   getPerformanceList,
 } from '@apis/kopis';
 
@@ -11,6 +12,7 @@ test('공연 목록 조회', async () => {
     endDate: '20240423',
     page: 1,
     size,
+    genreCode: 'AAAA',
   });
   expect(data?.length).toBe(size);
 }, 10000);
@@ -28,4 +30,10 @@ test('박스오피스조회', async () => {
     date: '20240423',
     stsType: 'day',
   });
+});
+
+test('공연 시설 상세 조회', async () => {
+  const id = 'FC001247';
+  const data = await getPerformanceFacilityDetail(id);
+  expect(data.mt10id).toBe(id);
 });

--- a/src/apis/kopis.d.ts
+++ b/src/apis/kopis.d.ts
@@ -95,3 +95,48 @@ export interface PerformanceStsType {
   주별: 'week';
   일별: 'day';
 }
+
+export interface PerformanceFacilityDetail {
+  // 공연시설명
+  fcltynm: string; // 올림픽공원
+  // 공연시설ID
+  mt10id: string; // FC001247
+  // 공연장 수
+  mt13cnt: number; // 9
+  // 시설특성
+  fcltychartr: string; // 기타(공공)
+  // 개관연도
+  opende: number; // 1986
+  // 객석 수
+  seatscale: number; // 32349
+  // 전화번호
+  telno: string; // 02-410-1114
+  // 홈페이지
+  relateurl: string; // http://www.olympicpark.co.kr/
+  // 주소
+  adres: string; // 서울특별시 송파구 올림픽로 424 올림픽공원 (방이동)
+  // 위도
+  la: number; // 37.52112
+  // 경도
+  lo: number; // 127.12836360000005
+  // 레스토랑
+  restaurant: 'Y' | 'N'; // Y
+  // 카페
+  cafe: 'Y' | 'N'; // Y
+  // 편의점
+  store: 'Y' | 'N'; // Y
+  // 놀이방
+  nolibang: 'Y' | 'N'; // N
+  // 수유실
+  suyu: 'Y' | 'N'; // N
+  // 장애시설-주차장
+  parkbarrier: 'Y' | 'N'; // N
+  // 장애시설-화장실
+  restbarrier: 'Y' | 'N'; // N
+  // 장애시설-경사로
+  runwbarrier: 'Y' | 'N'; // N
+  // 장애시설-엘리베이터
+  elevbarrier: 'Y' | 'N'; // N
+  // 주차지설
+  parkinglot: 'Y' | 'N'; // Y
+}

--- a/src/apis/kopis.ts
+++ b/src/apis/kopis.ts
@@ -1,6 +1,6 @@
 import {XMLParser} from 'fast-xml-parser';
 import {kopisInstance} from '@apis/axios';
-import {
+import type {
   PerformanceBoxOffice,
   PerformanceCategory,
   PerformanceGenre,
@@ -8,7 +8,8 @@ import {
   PerformanceInfo,
   PerformanceState,
   PerformanceStsType,
-} from '@interfaces/kopis.interface';
+  PerformanceFacilityDetail,
+} from './kopis.d';
 
 const parser = new XMLParser();
 
@@ -121,6 +122,17 @@ export const getPerformanceBoxOffice = async ({
     });
 
     return parser.parse(res.data).boxofs.boxof as PerformanceBoxOffice[];
+  } catch (e) {
+    console.error('Error in getBoxOffice:', e);
+    throw e;
+  }
+};
+
+export const getPerformanceFacilityDetail = async (id: string) => {
+  try {
+    const res = await kopisInstance.get(`/prfplc/${id}`);
+
+    return parser.parse(res.data).dbs.db as PerformanceFacilityDetail;
   } catch (e) {
     console.error('Error in getBoxOffice:', e);
     throw e;

--- a/src/components/cardlist/ArtList.tsx
+++ b/src/components/cardlist/ArtList.tsx
@@ -8,7 +8,7 @@ import {
   PerformanceCategory,
   PerformanceInfo,
   PerformanceStsType,
-} from '@interfaces/kopis.interface';
+} from '@apis/kopis.d';
 
 export interface ArtListProps {
   date: string;

--- a/src/components/cardlist/MainUpperCardBar.tsx
+++ b/src/components/cardlist/MainUpperCardBar.tsx
@@ -4,7 +4,7 @@ import Carousel, {Pagination} from 'react-native-snap-carousel';
 import MainUpperCard from '@components/carditem/MainUpperCard';
 import {colors} from '@styles/color';
 import {getPerformanceBoxOffice} from '@apis/kopis';
-import {PerformanceBoxOffice} from '@interfaces/kopis.interface';
+import {PerformanceBoxOffice} from '@apis/kopis.d';
 interface Item {
   image: any;
 }

--- a/src/components/categories/MainCategories.tsx
+++ b/src/components/categories/MainCategories.tsx
@@ -2,7 +2,7 @@ import React, {useState} from 'react';
 import {StyleSheet, View, Text, TouchableOpacity, FlatList} from 'react-native';
 import {atom, useAtom} from 'jotai';
 import {PerformanceGenre} from '@utils/category';
-import {PerformanceCategory} from '@interfaces/kopis.interface';
+import {PerformanceCategory} from '@apis/kopis.d';
 interface MainCategoriesProps {}
 
 export const selectAtom = atom('All');

--- a/src/template/home/DetailPage.tsx
+++ b/src/template/home/DetailPage.tsx
@@ -1,6 +1,6 @@
 import {getPerformanceDetail} from '@apis/kopis';
 import BackHeader from '@components/header/BackHeader';
-import {PerformanceDetailInfo} from '@interfaces/kopis.interface';
+import {PerformanceDetailInfo} from '@apis/kopis.d';
 import {RouteProp} from '@react-navigation/native';
 import {colors} from '@styles/color';
 import React, {useEffect, useState} from 'react';

--- a/src/template/home/HomeTemplates.tsx
+++ b/src/template/home/HomeTemplates.tsx
@@ -8,10 +8,7 @@ import SearchHeader from '@components/header/SearchHeader';
 import React from 'react';
 import {View} from 'react-native';
 import BackHeader from '@components/header/BackHeader';
-import {
-  PerformanceCategory,
-  PerformanceStsType,
-} from '@interfaces/kopis.interface';
+import {PerformanceCategory, PerformanceStsType} from '@apis/kopis.d';
 import {PerformanceGenre} from '@utils/category';
 import {useAtomValue} from 'jotai';
 interface HomeProps {

--- a/src/utils/category.ts
+++ b/src/utils/category.ts
@@ -1,4 +1,4 @@
-import {PerformanceCategory} from '@interfaces/kopis.interface';
+import {PerformanceCategory} from '@apis/kopis.d';
 
 export const PerformanceGenre: PerformanceCategory = {
   AAAA: '연극',


### PR DESCRIPTION
This closes #39 

# Summary:
공연 시설 상세 조회 API 추가

# Changelog:
기존의 kopis api 관련 타입들이 정의된 파일이 
interface폴더에서
apis로 옮겨가고 파일명이 수정되었습니다.

그로인해 이를 import 하던 부분들을 모두 수정하였으니 참고 바랍니다. 