### PR TITLE
fix: 이미지 다운샘플링 수정

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     <uses-permission android:name="android.permission.INTERNET" />
 
     <application
+      android:largeHeap="true"
       android:name=".MainApplication"
       android:label="@string/app_name"
       android:icon="@mipmap/ic_launcher"

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "ol": "^9.1.0",
         "react": "18.2.0",
         "react-native": "0.73.7",
+        "react-native-fast-image": "^8.6.3",
         "react-native-get-random-values": "^1.11.0",
         "react-native-safe-area-context": "^4.10.1",
         "react-native-screens": "^3.29.0",
@@ -12813,8 +12814,6 @@
     },
     "node_modules/npm/node_modules/cross-spawn/node_modules/which": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -12858,8 +12857,6 @@
     },
     "node_modules/npm/node_modules/debug/node_modules/ms": {
       "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "inBundle": true,
       "license": "MIT"
     },
@@ -14058,8 +14055,6 @@
     },
     "node_modules/npm/node_modules/semver/node_modules/lru-cache": {
       "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -14485,8 +14480,6 @@
     },
     "node_modules/npm/node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
       "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -15514,6 +15507,15 @@
         "react-native-windows": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-native-fast-image": {
+      "version": "8.6.3",
+      "resolved": "https://registry.npmjs.org/react-native-fast-image/-/react-native-fast-image-8.6.3.tgz",
+      "integrity": "sha512-Sdw4ESidXCXOmQ9EcYguNY2swyoWmx53kym2zRsvi+VeFCHEdkO+WG1DK+6W81juot40bbfLNhkc63QnWtesNg==",
+      "peerDependencies": {
+        "react": "^17 || ^18",
+        "react-native": ">=0.60.0"
       }
     },
     "node_modules/react-native-get-random-values": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "ol": "^9.1.0",
     "react": "18.2.0",
     "react-native": "0.73.7",
+    "react-native-fast-image": "^8.6.3",
     "react-native-get-random-values": "^1.11.0",
     "react-native-safe-area-context": "^4.10.1",
     "react-native-screens": "^3.29.0",

--- a/src/components/details/MainDetailsContent.tsx
+++ b/src/components/details/MainDetailsContent.tsx
@@ -1,14 +1,14 @@
 import {
   ScrollView,
-  FlatList,
   StyleSheet,
   Text,
   View,
   Dimensions,
   Image,
 } from 'react-native';
-import React, {useEffect, useState} from 'react';
+import React, {useState} from 'react';
 import {colors} from '@styles/color';
+import FastImage from 'react-native-fast-image';
 interface ImageUrl {
   styurl: string[];
 }
@@ -25,6 +25,7 @@ const MainDetailsContent = ({
   const windowWidth = Dimensions.get('window').width;
   const windowHeight = Dimensions.get('window').height;
   //const imageHeight = (windowWidth / imageSize.width) * imageSize.height;
+  const [imageHeightList, setImageHeightList] = useState<number[]>([]);
 
   return (
     <ScrollView
@@ -49,16 +50,30 @@ const MainDetailsContent = ({
       {detailImgUrls.styurl.length >= 1 && (
         <View>
           {detailImgUrls?.styurl.map((item: string, index: number) => (
-            <View
-              key={index}
-              style={{flex: 1, paddingBottom: 16, alignItems: 'center'}}>
+            <View key={index} style={{flex: 1, alignItems: 'center'}}>
               <Image
-                source={{uri: item}}
-                style={{
-                  width: windowWidth - 40,
-                  aspectRatio: 1 / 1,
+                onLoad={event => {
+                  const {width, height} = event.nativeEvent.source;
+                  const scaleFactor = width / windowWidth;
+                  const imageHeight = height / scaleFactor;
+                  setImageHeightList(prevState => {
+                    const newImageHeightList = [...prevState];
+                    newImageHeightList[index] = imageHeight;
+                    return newImageHeightList;
+                  });
                 }}
+                source={{uri: item}}
               />
+              {imageHeightList[index] && (
+                <FastImage
+                  resizeMode={FastImage.resizeMode.stretch}
+                  source={{uri: item}}
+                  style={{
+                    width: windowWidth,
+                    height: imageHeightList[index],
+                  }}
+                />
+              )}
             </View>
           ))}
         </View>

--- a/yarn.lock
+++ b/yarn.lock
@@ -4289,11 +4289,6 @@ fs.realpath@^1.0.0:
   resolved "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
 
-fsevents@^2.3.2:
-  version "2.3.3"
-  resolved "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz"
-  integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
-
 function-bind@^1.1.2:
   version "1.1.2"
   resolved "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz"
@@ -7081,6 +7076,11 @@ react-native-config@^1.5.1:
   resolved "https://registry.npmjs.org/react-native-config/-/react-native-config-1.5.1.tgz"
   integrity sha512-g1xNgt1tV95FCX+iWz6YJonxXkQX0GdD3fB8xQtR1GUBEqweB9zMROW77gi2TygmYmUkBI7LU4pES+zcTyK4HA==
 
+react-native-fast-image@^8.6.3:
+  version "8.6.3"
+  resolved "https://registry.npmjs.org/react-native-fast-image/-/react-native-fast-image-8.6.3.tgz"
+  integrity sha512-Sdw4ESidXCXOmQ9EcYguNY2swyoWmx53kym2zRsvi+VeFCHEdkO+WG1DK+6W81juot40bbfLNhkc63QnWtesNg==
+
 react-native-get-random-values@^1.11.0:
   version "1.11.0"
   resolved "https://registry.npmjs.org/react-native-get-random-values/-/react-native-get-random-values-1.11.0.tgz"
@@ -7136,7 +7136,7 @@ react-native-vector-icons@^10.0.3:
     prop-types "^15.7.2"
     yargs "^16.1.1"
 
-react-native@*, "react-native@^0.0.0-0 || >=0.60 <1.0", react-native@>=0.56, react-native@0.73.7:
+react-native@*, "react-native@^0.0.0-0 || >=0.60 <1.0", react-native@>=0.56, react-native@>=0.60.0, react-native@0.73.7:
   version "0.73.7"
   resolved "https://registry.npmjs.org/react-native/-/react-native-0.73.7.tgz"
   integrity sha512-LfI/INAC9jTf80bBHJQo0SfTEPQADsU8HoLaW7xQKjYXUX40dhu3AoyNEkMOHY4cpQyjEliQZ4dQpQMy733KRQ==
@@ -7202,7 +7202,7 @@ react-test-renderer@18.2.0:
     react-shallow-renderer "^16.15.0"
     scheduler "^0.23.0"
 
-react@*, "react@^16.0.0 || ^17.0.0 || ^18.0.0", react@^18.2.0, react@>=15.0.0, react@>=16.13.1, react@>=16.8, react@>=17.0.0, react@18.2.0:
+react@*, "react@^16.0.0 || ^17.0.0 || ^18.0.0", "react@^17 || ^18", react@^18.2.0, react@>=15.0.0, react@>=16.13.1, react@>=16.8, react@>=17.0.0, react@18.2.0:
   version "18.2.0"
   resolved "https://registry.npmjs.org/react/-/react-18.2.0.tgz"
   integrity sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==


### PR DESCRIPTION
리액트 네이티브에서는 Image 라이브러리로 com.facebook.fresco를 사용하는데 이 라이브러리가 안드로이드에서는 이미지 크기가 2048px을 넘을경우 자동으로 다운샘플링을 함.

이를 해결하기위해 이미지 라이브러리로 fast-image를 사용

This closes 

# Summary:

# Changelog: